### PR TITLE
chore(widget): add section widget

### DIFF
--- a/src/watchful.ts
+++ b/src/watchful.ts
@@ -17,6 +17,7 @@ import { WatchDynamoTableOptions, WatchDynamoTable } from './dynamodb';
 import { WatchEcsServiceOptions, WatchEcsService } from './ecs';
 import { WatchLambdaFunctionOptions, WatchLambdaFunction } from './lambda';
 import { WatchRdsAuroraOptions, WatchRdsAurora } from './rds-aurora';
+import { SectionWidget } from './widget/section';
 
 export interface WatchfulProps {
   readonly alarmEmail?: string;
@@ -73,12 +74,11 @@ export class Watchful extends Construct implements IWatchful {
   }
 
   public addSection(title: string, options: SectionOptions = {}) {
-    const markdown = [
-      `# ${title}`,
-      (options.links || []).map(link => `[button:${link.title}](${link.url})`).join(' | '),
-    ];
-
-    this.addWidgets(new cloudwatch.TextWidget({ width: 24, markdown: markdown.join('\n') }));
+    this.addWidgets(new SectionWidget({
+      titleLevel: 1,
+      titleMarkdown: title,
+      quicklinks: options.links,
+    }));
   }
 
   public watchScope(scope: Construct, options?: WatchfulAspectProps) {

--- a/src/widget/section.ts
+++ b/src/widget/section.ts
@@ -1,0 +1,73 @@
+import { TextWidget } from '@aws-cdk/aws-cloudwatch';
+import { QuickLink } from '../api';
+
+/**
+ * Props to create SectionWidget.
+ */
+export interface SectionWidgetProps {
+  /**
+   * widget width
+   * @default full width
+   */
+  readonly width?: number;
+  /**
+   * widget height
+   * @default 2
+   */
+  readonly height?: number;
+  /**
+   * title level (1 = H1, 2 = H2, etc)
+   * @default 1
+   */
+  readonly titleLevel?: number;
+  /**
+   * section title (might be markdown)
+   */
+  readonly titleMarkdown: string;
+  /**
+   * section description (might be markdown)
+   * @default empty
+   */
+  readonly descriptionMarkdown?: string;
+  /**
+   * quick links, that will be rendered as buttons
+   * @default none
+   */
+  readonly quicklinks?: QuickLink[];
+}
+
+/**
+ * Renders a section header in the following format:
+ *
+ * # Header
+ * Description
+ * [button:label1](url1) [button:label2](url2)
+ */
+export class SectionWidget extends TextWidget {
+  private static toMarkdown(props: SectionWidgetProps) {
+    const lines: string[] = [];
+
+    // title
+
+    const titlePrefix = '#'.repeat(props.titleLevel ?? 1);
+    lines.push(`${titlePrefix} ${props.titleMarkdown}`);
+
+    // description
+
+    if (props.descriptionMarkdown) {
+      lines.push(props.descriptionMarkdown);
+    }
+
+    // quick links
+
+    if (props.quicklinks && props.quicklinks.length > 0) {
+      lines.push(props.quicklinks.map(link => `[button:${link.title}](${link.url})`).join(' '));
+    }
+
+    return lines.join('\n\n');
+  }
+
+  constructor(props: SectionWidgetProps) {
+    super({ width: props.width ?? 24, height: props.height ?? 2, markdown: SectionWidget.toMarkdown(props) });
+  }
+}

--- a/test/widget/section.test.ts
+++ b/test/widget/section.test.ts
@@ -1,0 +1,45 @@
+import { SectionWidget } from '../../src/widget/section';
+
+test('correct size and content generated with minimum properties', () => {
+  // GIVEN
+  const widget = new SectionWidget({
+    titleMarkdown: 'Dummy Title',
+  });
+
+  // WHEN
+  const code = widget.toJson();
+
+  // THEN
+  expect(code).toHaveLength(1);
+  expect(code[0].width).toStrictEqual(24);
+  expect(code[0].height).toStrictEqual(2);
+  expect(code[0].properties.markdown).toStrictEqual('# Dummy Title');
+});
+
+test('correct size and content generated with all properties', () => {
+  // GIVEN
+  const widget = new SectionWidget({
+    titleMarkdown: 'Dummy Title',
+    width: 12,
+    height: 3,
+    titleLevel: 3,
+    descriptionMarkdown: 'Dummy Description in *Markdown*',
+    quicklinks: [
+      { url: 'https://github.com/awslabs/cdk-watchful', title: 'GitHub Repository' },
+      { url: 'https://github.com/awslabs', title: 'AWS Labs Homepage' },
+    ],
+  });
+
+  // WHEN
+  const code = widget.toJson();
+
+  // THEN
+  expect(code).toHaveLength(1);
+  expect(code[0].width).toStrictEqual(12);
+  expect(code[0].height).toStrictEqual(3);
+  expect(code[0].properties.markdown).toStrictEqual(
+    '### Dummy Title\n\n' +
+    'Dummy Description in *Markdown*\n\n' +
+    '[button:GitHub Repository](https://github.com/awslabs/cdk-watchful) [button:AWS Labs Homepage](https://github.com/awslabs)',
+  );
+});


### PR DESCRIPTION
Adds a section widget and uses it in the main Watchful object.

For the tests, I decided to use high-level comparison rather than snapshot tests.